### PR TITLE
Make build directory before building

### DIFF
--- a/build-pages.js
+++ b/build-pages.js
@@ -7,6 +7,7 @@ const mdtoc = require('markdown-toc')
 const { promisify } = require('util')
 const path = require("path")
 const fs = require("fs")
+const mkdir = promisify(fs.mkdir)
 const writeFile = promisify(fs.writeFile)
 const renderSass = promisify(sass.render)
 const ncp = promisify(NCP.ncp)
@@ -19,7 +20,7 @@ const pages = [
 
 async function compile() {
   console.log('Building docs')
-  
+
   console.log('Setting up MD parser')
   var md = require('markdown-it')({})
     .use(require('markdown-it-toc-and-anchor').default, {})
@@ -49,16 +50,18 @@ async function compile() {
   await writeFile('./pages/docs/toc.njk', toc)
 
   console.log('Building pages')
+  let buildDir = "./build"
+  await mkdir(buildDir, { recursive: true })
   await Promise.all(
     pages.map(page =>
       writeFile(
-        path.join("./build", page + ".html"),
+        path.join(buildDir, page + ".html"),
         nunjucks.render(path.join("./pages", page + ".njk")),
         err => err && console.error(err)
       )
     )
   )
-  
+
   console.log('Building sass')
   let app_sass = await renderSass({ file: './app.sass' })
   let clean_css = new CleanCSS({}).minify(app_sass.css.toString())


### PR DESCRIPTION
When I run `build-pages.js` in the fresh repo, the build process fails:
<details>
  <summary>Output (Click to expand)</summary>

```
$ build-pages.js
Building docs
Setting up MD parser
Fetching MD from github
Building NJK from MD
Generating TOC
Building NJK from MD TOC
Building pages
(node:12156) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open 'C:\Users\esprit\Development\vlang.io\build\index.html'
(node:12156) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:12156) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
</details>

This PR fixes the issue by making the build directory if it's missing. 