### PR TITLE
Use native font stack

### DIFF
--- a/app.sass
+++ b/app.sass
@@ -5,7 +5,7 @@ body, html
 
 body
   margin: 0px
-  font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif
 
 .content
   grid-area: content


### PR DESCRIPTION
Use native fonts for Windows and macOS.

Ref: https://getbootstrap.com/docs/4.0/content/reboot/#native-font-stack
Ref: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/